### PR TITLE
Added visibility param

### DIFF
--- a/lib/sauce-conf.js
+++ b/lib/sauce-conf.js
@@ -69,6 +69,11 @@ var webdriver   = require('wd'),
           'default':  'http://localhost:8080',
           'describe': 'Define the url to access tests through saucelabs'
       })
+      .options('visibilitySL', {
+        'alias':    'vi',
+        'default':  "public",
+        'describe': 'Visibilty of the session on saucelabs'
+      })      
       .options('connect', {
         'alias':    'ct',
         'default':  true,
@@ -113,7 +118,7 @@ var webdriver   = require('wd'),
         "device-orientation": argv.deviceOrientationSL,
         "tags"       : argv.tagsSL,
         "name"       : argv.sessionNameSL,
-        "public"     : "public",
+        "public"     : argv.visibiltySL,
         "build"      : auth.build,
         "tunnel-identifier": auth.tunnelIdentifier,
         "record-video": true


### PR DESCRIPTION
Adds `visibilitySL` so you can specify job visibility (still defaulting to `public`)